### PR TITLE
Changes for MinGW

### DIFF
--- a/get-gauche.sh
+++ b/get-gauche.sh
@@ -170,6 +170,20 @@ EOF
 }
 
 function do_check_for_windows3 {
+    # check version
+    case `uname -a` in
+        CYGWIN*|MINGW*)
+            cmp=`compare_version $desired_version 0.9.4`
+            case $cmp in
+                LE)
+                    echo "On Windows, this script doesn't support Gauche version"
+                    echo "0.9.4 or earlier."
+                    echo "Aborting."
+                    exit 1
+                    ;;
+            esac
+            ;;
+    esac
     # check install path
     case `uname -a` in
         CYGWIN*|MINGW*)

--- a/get-gauche.sh
+++ b/get-gauche.sh
@@ -169,7 +169,7 @@ function do_check_for_windows2 {
             case $cmp in
                 LE)
                     if echo "$prefix" | grep -q "[[:space:]]"; then
-                        echo "This version of Gauche can't be installed to the path"
+                        echo "Gauche version $desired_version can't be installed to the path"
                         echo "including white space directly."
                         echo "Please specify install path not including white space"
                         echo "and manually copy files to the real install path after"
@@ -427,8 +427,6 @@ case $desired_version in
     snapshot) desired_version=`curl -f $API/snapshot.txt 2>/dev/null`;;
 esac
 
-do_check_for_windows2
-
 #
 # Compare with current version
 #
@@ -451,10 +449,13 @@ else
         LE) echo "You already have Gauche $current_version in '$gosh_path'."
             if [ "$force" != yes ]; then
                 echo "No need to install.  (Use --force option to install $desired_version.)"
+                exit 0
             fi
             ;;
     esac
 fi
+
+do_check_for_windows2
 
 #
 # Proceed to install

--- a/get-gauche.sh
+++ b/get-gauche.sh
@@ -238,7 +238,7 @@ function do_fetch_and_install {
             esac
             for dll in $mingw_dll; do
                 if [ -f $mingwdir/bin/$dll ]; then
-                    cp $mingwdir/bin/$dll $prefix/bin
+                    cp $mingwdir/bin/$dll "$prefix/bin"
                 fi
             done
             ;;

--- a/get-gauche.sh
+++ b/get-gauche.sh
@@ -230,16 +230,17 @@ function do_fetch_and_install {
         MINGW*)
             case "$MSYSTEM" in
                 MINGW64|MINGW32)
-                    for dll in libwinpthread-1.dll; do
-                        if [ -f $mingwdir/bin/$dll ]; then
-                            cp $mingwdir/bin/$dll $prefix/bin
-                        fi
-                    done
+                    mingw_dll="libwinpthread-1.dll"
                     ;;
                 *)
-                    cp $mingwdir/bin/mingwm10.dll $prefix/bin
+                    mingw_dll="mingwm10.dll"
                     ;;
             esac
+            for dll in $mingw_dll; do
+                if [ -f $mingwdir/bin/$dll ]; then
+                    cp $mingwdir/bin/$dll $prefix/bin
+                fi
+            done
             ;;
     esac
 


### PR DESCRIPTION
MinGW環境で動作するように変更しました。
失敗する要因はなるべく最初にチェックして、
メッセージを表示して終了するようにしました。

＜変更内容＞
1. エラーチェックの追加
   - MSYS shell のチェック
   - カレントパスの空白チェック
   - openssl の使用不可のものをチェック
     (mingw64/mingw32 フォルダのものは make check 時に固まる)
   - 環境変数 MSYSTEM のチェック
   - インストール先パスの空白チェック

2. configure で gdbm を外した (make check が通らないため)

3. インストールファイルの追加
   (manifestファイル, examplesフォルダ, 依存dll (mingw-dist.sh と同様にした))


＜気になる点＞
- 英語のメッセージが。。。努力はしましたが。。。

- Gauche を普通にインストーラからインストールすると、
  `c:\Program Files\Gauche` にインストールされるが、
  prefix で空白入りのパスを指定すると、
  libtool 等でエラーになるようだった。
  とりあえず、空白入りのパスのときは メッセージを表示して終了するようにした。
  (空白なしのフォルダに一度生成してから 自動でコピーする方式も考えられるが、
  ちょっとこわいのでそこまではしなかった(管理者権限も必要になる))

- テストで1件でも失敗すると、テンポラリフォルダごと消えてやり直しになる。
  (ツールの性質上しかたないですが。。。)


＜テスト結果＞
OS : Windows 8.1 (64bit)
get-gauche : コミット 6da0560 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.2.0 (Rev1, Built by MSYS2 project))
空白のないフォルダに snapshot のインストールおよび起動 → 2018-2-18 OK

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 7.2.0 (Rev1, Built by MSYS2 project))
空白のないフォルダに snapshot のインストールおよび起動 → 2018-2-18 NG
( shirok/Gauche#340 の件でエラーになる )

開発環境3 : MinGW.org (32bitのみ) (gcc version 6.3.0 (MinGW.org GCC-6.3.0-1))
空白のないフォルダに snapshot のインストールおよび起動 → 2018-2-18 NG
(curl と cygpath がなかった。。。とりあえず対象外とする)
